### PR TITLE
added "fields/options/read" API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "middleware_micorservice",
+  "name": "middleware_microservice",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "middleware_micorservice",
+      "name": "middleware_microservice",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -23,7 +23,9 @@
         "cache-manager-memory-store": "^1.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "cors": "^2.8.5",
         "dotenv": "^16.4.5",
+        "helmet": "^8.0.0",
         "nest-winston": "^1.9.6",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.14",
@@ -5323,6 +5325,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.0.0.tgz",
+      "integrity": "sha512-VyusHLEIIO5mjQPUI1wpOAEu+wl6Q0998jzTxqUYGE45xCIcAxy3MsbEK/yyJUJ3ADeMoB6MornPH6GMWAf+Pw==",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hexoid": {

--- a/src/common/middleware/apiConfig.ts
+++ b/src/common/middleware/apiConfig.ts
@@ -330,6 +330,9 @@ export const apiList = {
   }),
   '/user/v1/academicyears/:identifier': createRouteObject(common_public_get),
   '/user/v1/form/read': createRouteObject(common_public_get),
+  '/user/v1/fields/options/read': createRouteObject({
+    post: {},
+  }),
   //event-service
   //event
   '/event-service/event/v1/create': createRouteObject({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint for reading field options at `'/user/v1/fields/options/read'`, enhancing the API's capabilities for clients. 

- **Bug Fixes**
	- No changes affecting existing methods or roles, ensuring API integrity is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->