### PR TITLE
Removed cohort Hierarchy api as it does not require academic year

### DIFF
--- a/src/common/middleware/apiConfig.ts
+++ b/src/common/middleware/apiConfig.ts
@@ -1485,7 +1485,6 @@ export const apiListForAcademicYear = [
   '/user/v1/cohortmember/read/:identifier',
   '/user/v1/cohort/create',
   '/user/v1/cohort/search',
-  '/user/v1/cohort/cohortHierarchy/:identifier',
   '/user/v1/cohort/mycohorts/:identifier',
 ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined API routes by removing the `/user/v1/cohort/cohortHierarchy/:identifier` endpoint from the academic year-related API calls.

- **Bug Fixes**
	- Ensured existing functionality for handling API requests remains consistent despite the removal of the endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->