### PR TITLE
White listed pratham specific microservices import user api

### DIFF
--- a/src/common/middleware/apiConfig.ts
+++ b/src/common/middleware/apiConfig.ts
@@ -163,6 +163,10 @@ export const apiList = {
   '/user/v1/auth/login': createRouteObject({
     post: {},
   }),
+  //public api
+  '/prathamservice/v1/import-user': createRouteObject({
+    post: {},
+  }),
   //public api for run cron job for send event notification
   '/prathamservice/v1/cronjob': createRouteObject({
     get: {},
@@ -1554,7 +1558,8 @@ export const publicAPI = [
   '/action/composite/v3/search',
   '/api/content/v1/read/:identifier',
   '/api/course/v1/hierarchy/:identifier',
-  '/prathamservice/v1/cronjob'
+  '/prathamservice/v1/cronjob',
+  '/prathamservice/v1/import-user'
 ];
 
 // api which required academic year


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new public API endpoint for importing users at `'/prathamservice/v1/import-user'`.
- **Improvements**
	- Updated the public API list to include the new import-user endpoint while retaining the existing cron job endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->