### PR TITLE
PS-2756 -added_url_for_send_OTP_and_verify_OTP

### DIFF
--- a/src/common/middleware/apiConfig.ts
+++ b/src/common/middleware/apiConfig.ts
@@ -216,6 +216,12 @@ export const apiList = {
       // ROLE_CHECK: rolesGroup.admin_team_leader_teacher,
     },
   }),
+  '/user/v1/password-reset-otp': createRouteObject({
+    post: {
+      // PRIVILEGE_CHECK: privilegeGroup.users.delete,
+      // ROLE_CHECK: rolesGroup.admin_team_leader_teacher,
+    },
+  }),
   //need confirmation
   '/user/v1/forgot-password': createRouteObject({
     post: {
@@ -1589,6 +1595,7 @@ export const publicAPI = [
   '/action/questionset/private/v2/read/:identifier',
   '/action/object/category/definition/v1/read',
   '/user/v1/password-reset-link',
+  '/user/v1/password-reset-otp',
   '/user/v1/forgot-password',
   '/user/v1/send-otp',
   '/user/v1/verify-otp',

--- a/src/common/middleware/apiConfig.ts
+++ b/src/common/middleware/apiConfig.ts
@@ -619,6 +619,21 @@ export const apiList = {
     },
   }),
 
+  //OTP
+  '/user/v1/send-otp': createRouteObject({
+    post: {
+      // PRIVILEGE_CHECK: privilegeGroup.users.delete,
+      // ROLE_CHECK: rolesGroup.admin_team_leader_teacher,
+    },
+  }),
+  '/user/v1/verify-otp': createRouteObject({
+    post: {
+      // PRIVILEGE_CHECK: privilegeGroup.users.delete,
+      // ROLE_CHECK: rolesGroup.admin_team_leader_teacher,
+    },
+  }),
+
+
   //sunbird knowlg and inQuiry service
   //public
 
@@ -1575,6 +1590,8 @@ export const publicAPI = [
   '/action/object/category/definition/v1/read',
   '/user/v1/password-reset-link',
   '/user/v1/forgot-password',
+  '/user/v1/send-otp',
+  '/user/v1/verify-otp',
   '/questionset/v5/private/read/:identifier',
   '/user/v1/form/read',
   '/action/composite/v3/search',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced two new API endpoints for OTP functionality: `/user/v1/send-otp` and `/user/v1/verify-otp`.
	- Added a new endpoint for password reset OTP: `/user/v1/password-reset-otp`.

- **Documentation**
	- Updated API configuration to include new endpoints in the public API list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->