### PR TITLE
Added Header for multipart/form-data APIs

### DIFF
--- a/src/common/middleware/middleware.service.ts
+++ b/src/common/middleware/middleware.service.ts
@@ -165,7 +165,8 @@ export class MiddlewareServices {
           fullUrl,
           req.method,
           formData,
-          token,
+          req.headers,
+          token,         
         );
       }
     } else {

--- a/src/middleware/gateway.service.ts
+++ b/src/middleware/gateway.service.ts
@@ -77,14 +77,17 @@ export class GatewayService {
     url: string,
     method,
     formData: any,
+    oheaders: any,
     token?: string,
   ) {    
     try {   
-      let response;
+      let response;      
       const headers = { 
         ...formData.getHeaders(),
-        ...(token ? { Authorization: `Bearer ${token}` } : {}), 
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       };
+      if (oheaders?.tenantid) headers.tenantid = oheaders.tenantid;
+      if (oheaders?.organisationid) headers.organisationid = oheaders.organisationid;
       response = await axios({
         method: method.toLowerCase(), 
         url, 


### PR DESCRIPTION
Currently tenantid and organisationid are not pass for the APIs with multipart/form-data , added this header.